### PR TITLE
去掉无意义的判断

### DIFF
--- a/src/Storage/Vertex.Storage.Linq2db/Storage/TxEventStorage.cs
+++ b/src/Storage/Vertex.Storage.Linq2db/Storage/TxEventStorage.cs
@@ -40,10 +40,7 @@ namespace Vertex.Storage.Linq2db.Storage
             try
             {
                 var copyResult = await table.BulkCopyAsync(inputList.Select(o => o.Value));
-                if (copyResult.RowsCopied == inputList.Count)
-                {
-                    inputList.ForEach(wrap => wrap.TaskSource.TrySetResult(true));
-                }
+                inputList.ForEach(wrap => wrap.TaskSource.TrySetResult(true));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
前置条件：如果数量不相等肯定会报错。这样情况下无需判数量是否相等。