### PR TITLE
初始化时候读取表结构，linq2db默认获取存储过程，设置为不获取存储过程，不然会自动执行

### DIFF
--- a/src/Storage/Vertex.Storage.Linq2db/Storage/ConnExtensions.cs
+++ b/src/Storage/Vertex.Storage.Linq2db/Storage/ConnExtensions.cs
@@ -54,7 +54,9 @@ namespace Vertex.Storage.Linq2db.Storage
             else
             {
                 var sp = conn.DataProvider.GetSchemaProvider();
-                var dbSchema = sp.GetSchema(conn);
+
+                // 这里会获取和执行存储过程，这需要设置不获取存储过程，
+                var dbSchema = sp.GetSchema(conn, new LinqToDB.SchemaProvider.GetSchemaOptions { GetProcedures = false });
                 return dbSchema.Tables.Select(t => t.TypeName).ToList();
             }
         }


### PR DESCRIPTION
初始化时候读取表结构，linq2db默认获取存储过程，设置为不获取存储过程，不然会自动执行