### PR TITLE
fix:升级linq2db到5.4.1版，解决postgress不能使用的问题，并升级postgress sdk和sqlclient s…

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -2,6 +2,7 @@
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <PackageReference Update="Microsoft.Orleans.Clustering.Redis" Version="8.2.0" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Update="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Update="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
@@ -29,7 +30,7 @@
     <PackageReference Update="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Update="System.Text.Json" Version="8.0.5" />
     <PackageReference Update="System.Threading.Tasks.Dataflow" Version="8.0.1" />
-    <PackageReference Update="Confluent.Kafka" Version="2.6.0" />
+    <PackageReference Update="Confluent.Kafka" Version="2.6.1" />
     <PackageReference Update="RabbitMQ.Client" Version="6.8.1" />
     <PackageReference Update="System.Reactive" Version="6.0.1" />
     <PackageReference Update="linq2db" Version="5.4.1" />

--- a/Packages.props
+++ b/Packages.props
@@ -32,7 +32,7 @@
     <PackageReference Update="Confluent.Kafka" Version="2.6.0" />
     <PackageReference Update="RabbitMQ.Client" Version="6.8.1" />
     <PackageReference Update="System.Reactive" Version="6.0.1" />
-    <PackageReference Update="linq2db" Version="4.1.1" />
+    <PackageReference Update="linq2db" Version="5.4.1" />
     <PackageReference Update="IdGen" Version="3.0.7" />
 
     <PackageReference Update="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" PrivateAssets="All" />

--- a/examples/Packages.props
+++ b/examples/Packages.props
@@ -5,7 +5,7 @@
    <PackageReference Update="Microsoft.Extensions.Hosting" Version="8.0.1" />
    <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
    <PackageReference Update="MySqlConnector" Version="2.2.0" />
-   <PackageReference Update="Npgsql" Version="7.0.0" />
-   <PackageReference Update="Microsoft.Data.SqlClient" Version="5.0.0" />
+   <PackageReference Update="Npgsql" Version="9.0.3" />
+   <PackageReference Update="Microsoft.Data.SqlClient" Version="6.0.1" />
  </ItemGroup>
 </Project>

--- a/src/Storage/Vertex.Storage.Linq2db/Db/EventDb.cs
+++ b/src/Storage/Vertex.Storage.Linq2db/Db/EventDb.cs
@@ -1,5 +1,7 @@
 ﻿using LinqToDB;
 using LinqToDB.Data;
+using LinqToDB.Mapping;
+
 using Vertex.Storage.Linq2db.Entities;
 
 namespace Vertex.Storage.Linq2db.Db
@@ -9,7 +11,7 @@ namespace Vertex.Storage.Linq2db.Db
         public EventDb(string name)
             : base(name)
         {
-            this.MappingSchema.EntityDescriptorCreatedCallback = (schema, entityDescriptor) =>
+            MappingSchema.EntityDescriptorCreatedCallback = (schema, entityDescriptor) =>
             {
                 entityDescriptor.TableName = entityDescriptor.TableName.ToLower();
                 foreach (var entityDescriptorColumn in entityDescriptor.Columns)

--- a/src/Storage/Vertex.Storage.Linq2db/Db/SnapshotDb.cs
+++ b/src/Storage/Vertex.Storage.Linq2db/Db/SnapshotDb.cs
@@ -1,5 +1,7 @@
 ﻿using LinqToDB;
 using LinqToDB.Data;
+using LinqToDB.Mapping;
+
 using Vertex.Storage.Linq2db.Entities;
 
 namespace Vertex.Storage.Linq2db.Db
@@ -9,7 +11,7 @@ namespace Vertex.Storage.Linq2db.Db
         public SnapshotDb(string name)
             : base(name)
         {
-            this.MappingSchema.EntityDescriptorCreatedCallback = (schema, entityDescriptor) =>
+            MappingSchema.EntityDescriptorCreatedCallback = (schema, entityDescriptor) =>
             {
                 entityDescriptor.TableName = entityDescriptor.TableName.ToLower();
                 foreach (var entityDescriptorColumn in entityDescriptor.Columns)

--- a/src/Storage/Vertex.Storage.Linq2db/Db/SubSnapshotDb.cs
+++ b/src/Storage/Vertex.Storage.Linq2db/Db/SubSnapshotDb.cs
@@ -1,5 +1,7 @@
 ﻿using LinqToDB;
 using LinqToDB.Data;
+using LinqToDB.Mapping;
+
 using Vertex.Storage.Linq2db.Entities;
 
 namespace Vertex.Storage.Linq2db.Db
@@ -9,7 +11,7 @@ namespace Vertex.Storage.Linq2db.Db
         public SubSnapshotDb(string name)
             : base(name)
         {
-            this.MappingSchema.EntityDescriptorCreatedCallback = (schema, entityDescriptor) =>
+            MappingSchema.EntityDescriptorCreatedCallback = (schema, entityDescriptor) =>
             {
                 entityDescriptor.TableName = entityDescriptor.TableName.ToLower();
                 foreach (var entityDescriptorColumn in entityDescriptor.Columns)


### PR DESCRIPTION
升级linq2db到5.4.1版，解决postgres不能使用的问题，并升级postgres sdk和sqlclient sdk到最新版，测试通过